### PR TITLE
Introduce biweekly movement

### DIFF
--- a/src/Data/Time/Calendar/DateConversions.hs
+++ b/src/Data/Time/Calendar/DateConversions.hs
@@ -1,21 +1,25 @@
 module Data.Time.Calendar.DateConversions
     -- beginning
     ( beginningOfWeek
+    , beginningOfBiweek
     , beginningOfMonth
     , beginningOfQuarter
     , beginningOfYear
     -- end
     , endOfWeek
+    , endOfBiweek
     , endOfMonth
     , endOfQuarter
     , endOfYear
     -- next
     , nextWeek
+    , nextBiweek
     , nextMonth
     , nextQuarter
     , nextYear
     -- previous
     , previousWeek
+    , previousBiweek
     , previousMonth
     , previousQuarter
     , previousYear
@@ -23,6 +27,7 @@ module Data.Time.Calendar.DateConversions
 
 import qualified Data.Dates as D
 import qualified Data.Time as T
+import qualified Data.Time.Calendar.WeekDate as T
 
 beginningOfWeek :: T.Day -> T.Day
 beginningOfWeek d =
@@ -31,6 +36,18 @@ beginningOfWeek d =
         else T.addDays (-8) $ nextMonday d
   where
     nextMonday = D.dateTimeToDay . D.nextMonday . D.dayToDateTime
+
+beginningOfBiweek :: T.Day -> T.Day
+beginningOfBiweek d =
+    if odd w'
+        then beginningOfWeek d
+        else T.addDays (-7) $ beginningOfWeek d
+  where
+    (_, w, dow) = T.toWeekDate d
+    w' =
+        if dow == 7
+            then w + 1
+            else w
 
 beginningOfMonth :: T.Day -> T.Day
 beginningOfMonth d = T.fromGregorian year month 1
@@ -51,6 +68,9 @@ beginningOfYear d = T.fromGregorian year 1 1
 endOfWeek :: T.Day -> T.Day
 endOfWeek = T.addDays 6 . beginningOfWeek
 
+endOfBiweek :: T.Day -> T.Day
+endOfBiweek = T.addDays 13 . beginningOfBiweek
+
 endOfMonth :: T.Day -> T.Day
 endOfMonth = T.addDays (-1) . T.addGregorianMonthsClip 1 . beginningOfMonth
 
@@ -63,6 +83,9 @@ endOfYear = T.addDays (-1) . T.addGregorianYearsClip 1 . beginningOfYear
 nextWeek :: T.Day -> T.Day
 nextWeek = T.addDays 7 . beginningOfWeek
 
+nextBiweek :: T.Day -> T.Day
+nextBiweek = T.addDays 14 . beginningOfBiweek
+
 nextMonth :: T.Day -> T.Day
 nextMonth = T.addGregorianMonthsClip 1 . beginningOfMonth
 
@@ -74,6 +97,9 @@ nextYear = T.addGregorianMonthsClip 12 . beginningOfYear
 
 previousWeek :: T.Day -> T.Day
 previousWeek = T.addDays (-7) . beginningOfWeek
+
+previousBiweek :: T.Day -> T.Day
+previousBiweek = T.addDays (-14) . beginningOfBiweek
 
 previousMonth :: T.Day -> T.Day
 previousMonth = T.addGregorianMonthsClip (-1) . beginningOfMonth

--- a/test/Data/Time/Calendar/DateConversionsSpec.hs
+++ b/test/Data/Time/Calendar/DateConversionsSpec.hs
@@ -24,6 +24,12 @@ spec =
         describe "beginningOfWeek" $
             it "returns Sunday" $
             property $ \d -> dayToWeekDay (beginningOfWeek d) `shouldBe` D.Sunday
+        describe "beginningOfBiweek" $
+            it "returns a Sunday in a two-week window" $
+            property $ \d -> do
+                dayToWeekDay (beginningOfBiweek d) `shouldBe` D.Sunday
+                T.diffDays (beginningOfBiweek d) d `shouldSatisfy` (<= 13)
+                T.diffDays (beginningOfBiweek d) d `shouldSatisfy` (>= -13)
         describe "beginningOfMonth" $
             it "retains the month independent of day" $
             property $ \d -> do
@@ -48,6 +54,12 @@ spec =
                 dayToWeekDay (endOfWeek d) `shouldBe` D.Saturday
                 endOfWeek d `shouldSatisfy` (>= d)
                 T.diffDays (endOfWeek d) d `shouldSatisfy` (<= 7)
+        describe "endOfBiweek" $
+            it "returns the correct Saturday" $
+            property $ \d -> do
+                dayToWeekDay (endOfBiweek d) `shouldBe` D.Saturday
+                endOfBiweek d `shouldSatisfy` (>= d)
+                T.diffDays (endOfBiweek d) d `shouldSatisfy` (<= 13)
         describe "endOfMonth" $
             it "retains the month and year independent of day" $
             property $ \d -> do
@@ -74,6 +86,13 @@ spec =
                 nextWeek d `shouldBe` T.addDays 7 (beginningOfWeek d)
                 T.diffDays (nextWeek d) d `shouldSatisfy` (<= 7)
                 T.diffDays (nextWeek d) d `shouldSatisfy` (> 0)
+        describe "nextBiweek" $
+            it "returns a Sunday within the next 14 days" $
+            property $ \d -> do
+                dayToWeekDay (nextBiweek d) `shouldBe` D.Sunday
+                nextBiweek d `shouldBe` T.addDays 14 (beginningOfBiweek d)
+                T.diffDays (nextBiweek d) d `shouldSatisfy` (<= 14)
+                T.diffDays (nextBiweek d) d `shouldSatisfy` (> 0)
         describe "nextMonth" $
             it "returns the first day of the next month" $
             property $ \d -> do
@@ -108,6 +127,13 @@ spec =
                 previousWeek d `shouldBe` T.addDays (-7) (beginningOfWeek d)
                 T.diffDays (previousWeek d) d `shouldSatisfy` (<= -7)
                 T.diffDays (previousWeek d) d `shouldSatisfy` (> -14)
+        describe "previousBiweek" $
+            it "returns a Sunday within the past fourteen days" $
+            property $ \d -> do
+                dayToWeekDay (previousBiweek d) `shouldBe` D.Sunday
+                previousBiweek d `shouldBe` T.addDays (-14) (beginningOfBiweek d)
+                T.diffDays (previousBiweek d) d `shouldSatisfy` (<= -14)
+                T.diffDays (previousBiweek d) d `shouldSatisfy` (> -28)
         describe "previousMonth" $
             it "returns the first day of the previous month" $
             property $ \d -> do


### PR DESCRIPTION
What?
=====

With the baseline set for weekly movement, this introduces biweekly movement as
well.

This requires a bit of value juggling due to
Data.Time.Calendar.WeekDate.toWeekDate calculating weeks as starting on Monday
instead of Sunday.